### PR TITLE
Small provision fixes

### DIFF
--- a/ansible/tasks/development.yml
+++ b/ansible/tasks/development.yml
@@ -29,10 +29,10 @@
 
 # Storage
 - name: MySQL
-  action: apt pkg=mysql-server state=installed
-
-- name: MySQL
-  action: apt pkg=python-mysqldb state=installed
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - mysql-server
+    - python-mysqldb
 
 # 'localhost' needs to be the last item for idempotency, see
 # http://ansible.cc/docs/modules.html#mysql-user


### PR DESCRIPTION
I encountered some issues upon booting the vagrant setup. Issues like:

```
TASK: [Apache | Changing lock file owner/group] *******************************
failed: [default] => {"failed": true, "gid": 0, "group": "root", "item": "", "mode": "0755", "owner": "www-data", "path": "/var/lock/apache2", "size": 40, "state": "directory", "uid": 33}
msg: refusing to convert between directory and file for None
```

Fixed in https://github.com/pascaldevink/amsterdamphp.nl/commit/aa2688fbb66812e249807c088e1096211277a9ed

```
TASK: [MySQL] *****************************************************************
failed: [default] => {"failed": true, "item": "", "parsed": false}
```

Fixed in https://github.com/pascaldevink/amsterdamphp.nl/commit/7400c78fa604083b786b45f39e15e01155e438db
