### PR TITLE
JQuery missing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
             },
             amsterdamphpjs: {
                 src: [
-                    'web/js/jquery.js',
+                    'bower_components/jquery/jquery.js',
                     'bower_components/bootstrap/js/transition.js',
                     'bower_components/bootstrap/js/alert.js',
                     'bower_components/bootstrap/js/button.js',

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
         "**/*"
     ],
     "dependencies": {
-        "jQuery": "1.10.*",
+        "jquery": "1.10.*",
         "html5shiv": "3.6.*",
         "bootstrap": "3.0.*",
         "respond": "1.4.*",


### PR DESCRIPTION
The proper grunt setup could not find `bower_components/jquery/jquery.js` so i pointed it to `web/js/jquery.js`  and it worked long enough for a deploy. It is however not a ideal solution as it may have race conditions.
