### PR TITLE
Added Jeroen on the contact page

### DIFF
--- a/src/AmsterdamPHP/Bundle/SiteBundle/Resources/views/Contact/index.html.twig
+++ b/src/AmsterdamPHP/Bundle/SiteBundle/Resources/views/Contact/index.html.twig
@@ -20,9 +20,9 @@
                     <h4>Organizers</h4>
                     <div class="row organizers">
                         <div class="col-lg-3 col-md-3"><img src="{{ gravatar('rdohms@amsterdamphp.nl') }}" title="Rafael Dohms" alt="Rafael Dohms"/></div>
-                        <div class="col-lg-3 col-md-3"><img src="{{ gravatar('frank@amsterdamphp.nl') }}"  title="Frank van den Brink" alt="Frank van den Brink"/></div>
                         <div class="col-lg-3 col-md-3"><img src="{{ gravatar('pascal@amsterdamphp.nl') }}" title="Pascal de Vink" alt="Pascal de Vink"/></div>
                         <div class="col-lg-3 col-md-3"><img src="{{ gravatar('jakub@amsterdamphp.nl') }}"  title="Jakub Gadkowski" alt="Jakub Gadkowski"/></div>
+                        <div class="col-lg-3 col-md-3"><img src="{{ gravatar('jeroen@amsterdamphp.nl') }}"  title="Jeroen Groeneweg" alt="Jeroen Groeneweg"/></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
# Why

As Jeroen is now an official member of the team, I've added him to the contact page. Since Frank has left us (for now :wink: ), I've removed him to avoid confusion.
# How does it look?

Well, sadly, @jakubgg never uploaded a gravatar of himself, and @jeroen-groeneweg didn't know yet, so it looks like this:
![screen shot 2014-09-22 at 23 32 09](https://cloud.githubusercontent.com/assets/106844/4364436/000f7594-42a0-11e4-809a-3b90c5383ccc.png)
But that's easily remedied if @jakubgg and @jeroen-groeneweg both upload their faces to gravater :wink: 
