### PR TITLE
Added link to the raffler in the header menu

### DIFF
--- a/src/AmsterdamPHP/Bundle/SiteBundle/Resources/views/_header.html.twig
+++ b/src/AmsterdamPHP/Bundle/SiteBundle/Resources/views/_header.html.twig
@@ -23,6 +23,9 @@
                 <li {% if app.request.attributes.get('_route') == 'amsphp_contact' %}class="active"{% endif %}>
                     <a href="{{ path('amsphp_contact') }}">Contact</a>
                 </li>
+                <li>
+                    <a href="//raffles.amsterdamphp.nl">Raffles</a>
+                </li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
# Why

In #68 it was suggested that maybe a general link to the raffler would suffice. This PR is to discuss that idea.
# How it looks

![screen shot 2014-09-23 at 20 33 22](https://cloud.githubusercontent.com/assets/106844/4377594/5ff9a7bc-4350-11e4-8cf6-b7842a45ca9d.png)
