### PR TITLE
Changed uglify reporting option to minified

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
         uglify: {
             ie8: {
                 options: {
-                    report: 'gzip',
+                    report: 'min',
                     banner: '<%= banner %>'
                 },
                 files: {
@@ -64,7 +64,7 @@ module.exports = function(grunt) {
             },
             amsterdamphpjs: {
                 options: {
-                    report: 'gzip',
+                    report: 'min',
                     banner: '<%= banner %>'
                 },
                 files: {
@@ -77,7 +77,7 @@ module.exports = function(grunt) {
         cssmin: {
             amsterdamphpcss: {
                 options: {
-                    report: 'gzip',
+                    report: 'min',
                     banner: '<%= banner %>'
                 },
                 src: [


### PR DESCRIPTION
# Why

Changed the reporting option for the uglier from gzip to min for a drastic speed increase. As per the documentation (https://github.com/gruntjs/grunt-contrib-uglify#report), the gzip reporting is nice, but not necessary (ie it doesn't  actually gzips the files) and way slower than just reporting on the minification file size.

This increases the productivity when doing lots of frontend related tasks.
