### PR TITLE
#22: 

### DIFF
--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -4,7 +4,7 @@
   vars:
     root_folder: /var/www/amsphp
     document_root: "{{ root_folder }}/web/"
-    write_to_folder: /dev/shm
+    write_to_folder: /var/shm
     dbname: amsphp
     dbuser: root
     dbpasswd: root

--- a/ansible/tasks/development.yml
+++ b/ansible/tasks/development.yml
@@ -71,6 +71,7 @@
     - php5-intl
     - php5-memcached
     - php5-xdebug
+    - libapache2-mod-php5
 
 # Configurations
 

--- a/ansible/tasks/host.yml
+++ b/ansible/tasks/host.yml
@@ -7,7 +7,13 @@
   notify: restart apache
 
 - name: Apache | Disable Default Host Config
+  command: a2dissite default
+  ignore_errors: true
+  notify: restart apache
+
+- name: Apache | Disable Default Host Config
   command: a2dissite 000-default.conf
+  ignore_errors: true
   notify: restart apache
 
 - name: Apache | Ensure application files are present

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -73,7 +73,7 @@ class AppKernel extends Kernel
     public function getLogDir()
     {
         if (in_array($this->environment, array('dev', 'test'))) {
-            return '/dev/shm/amsphp/logs';
+            return '/var/shm/amsphp/logs';
         }
 
         return parent::getLogDir();


### PR DESCRIPTION
# What

Fixed some vagrant/ansible things like:
- The location of the writable folder
- The disabling of the default host
- The apache2 php5 module
- [X] fix race conditions for assetic:watch and supervisord (missing app folder at boot)
- [X] eliminate race conditions with using `dev/shm/amsphp` for logs
