### PR TITLE
Fix issue #89 by changing file permissions on /etc/php5/cli/php.ini

### DIFF
--- a/ansible/tasks/development.yml
+++ b/ansible/tasks/development.yml
@@ -81,7 +81,7 @@
     - restart apache
 
 - name: PHP | Config Memory Limit
-  ini_file: dest=/etc/php5/cli/php.ini section=global option=memory_limit value=256M mode=0600
+  ini_file: dest=/etc/php5/cli/php.ini section=global option=memory_limit value=256M mode=0644
   notify:
     - restart apache
 


### PR DESCRIPTION
This way PHP can parse `/etc/php5/cli/php.ini` to process the `memory_limit` ini setting.
Also see #89 