### PR TITLE
Make the loading of maps work on both HTTP and HTTPS

### DIFF
--- a/src/AmsterdamPHP/Bundle/SiteBundle/Resources/views/Default/_next_event.html.twig
+++ b/src/AmsterdamPHP/Bundle/SiteBundle/Resources/views/Default/_next_event.html.twig
@@ -53,7 +53,7 @@
 </div>
 
 
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
+<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false"></script>
 <script type="text/javascript">
     var myOptions = {
         zoom: {{ (event.venue is defined)? 15:10}},


### PR DESCRIPTION
Turns out #95 doesn't mention the map doesn't work on HTTPS while it does on HTTP.

Fixes #95 